### PR TITLE
A Patch for issue #9

### DIFF
--- a/api-management-actions/powershell/clean-up.ps1
+++ b/api-management-actions/powershell/clean-up.ps1
@@ -15,7 +15,7 @@ param(
 $resourceGroups = Get-AzResourceGroup;
 
 foreach ($resourceGroup in $resourceGroups) {
-    if ($resourceGroup.ResourceGroupName.StartsWith($groupId), 'CurrentCultureIgnoreCase') {
+    if ($resourceGroup.ResourceGroupName.StartsWith($groupId, 'CurrentCultureIgnoreCase')) {
         Remove-AzResourceGroup -Name $resourceGroup.ResourceGroupName -Force -AsJob
         Write-Host "Deleted resource group $($resourceGroup.ResourceGroupName)"
     }

--- a/function-app-actions/powershell/clean-up.ps1
+++ b/function-app-actions/powershell/clean-up.ps1
@@ -15,7 +15,7 @@ param(
 $resourceGroups = Get-AzResourceGroup;
 
 foreach ($resourceGroup in $resourceGroups) {
-    if ($resourceGroup.ResourceGroupName.StartsWith($groupId), 'CurrentCultureIgnoreCase') {
+    if ($resourceGroup.ResourceGroupName.StartsWith($groupId, 'CurrentCultureIgnoreCase')) {
         Remove-AzResourceGroup -Name $resourceGroup.ResourceGroupName -Force -AsJob
         Write-Host "Deleted resource group $($resourceGroup.ResourceGroupName)"
     }

--- a/integration-account-connections/powershell/clean-up.ps1
+++ b/integration-account-connections/powershell/clean-up.ps1
@@ -15,7 +15,7 @@ param(
 $resourceGroups = Get-AzResourceGroup;
 
 foreach ($resourceGroup in $resourceGroups) {
-    if ($resourceGroup.ResourceGroupName.StartsWith($groupId), 'CurrentCultureIgnoreCase') {
+    if ($resourceGroup.ResourceGroupName.StartsWith($groupId, 'CurrentCultureIgnoreCase')) {
         Remove-AzResourceGroup -Name $resourceGroup.ResourceGroupName -Force -AsJob
         Write-Host "Deleted resource group $($resourceGroup.ResourceGroupName)"
     }

--- a/service-bus-connections/powershell/clean-up.ps1
+++ b/service-bus-connections/powershell/clean-up.ps1
@@ -15,7 +15,7 @@ param(
 $resourceGroups = Get-AzResourceGroup;
 
 foreach ($resourceGroup in $resourceGroups) {
-    if ($resourceGroup.ResourceGroupName.StartsWith($groupId), 'CurrentCultureIgnoreCase') {
+    if ($resourceGroup.ResourceGroupName.StartsWith($groupId, 'CurrentCultureIgnoreCase')) {
         Remove-AzResourceGroup -Name $resourceGroup.ResourceGroupName -Force -AsJob
         Write-Host "Deleted resource group $($resourceGroup.ResourceGroupName)"
     }

--- a/storage-account-connections/powershell/clean-up.ps1
+++ b/storage-account-connections/powershell/clean-up.ps1
@@ -15,7 +15,7 @@ param(
 $resourceGroups = Get-AzResourceGroup;
 
 foreach ($resourceGroup in $resourceGroups) {
-    if ($resourceGroup.ResourceGroupName.StartsWith($groupId), 'CurrentCultureIgnoreCase') {
+    if ($resourceGroup.ResourceGroupName.StartsWith($groupId, 'CurrentCultureIgnoreCase')) {
         Remove-AzResourceGroup -Name $resourceGroup.ResourceGroupName -Force -AsJob
         Write-Host "Deleted resource group $($resourceGroup.ResourceGroupName)"
     }


### PR DESCRIPTION
## Purpose
To patch issue #9 
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
* Manually create some resource groups in the Azure portal using a name you won't be using for the automation groupId.
* Run one of the automation scripts with a different groupId so as not to conflict with the previous step.
* Run clean-up.ps1.

```

## What to Check
Without the patch, your subscription will be cleared out of ALL resources. With this patch only resource groups with a name starting with the provided groupId will be deleted.

## Other Information
YOU MUST test this in a subscription with resources not created by the automation scripts within the rest of this repo. I suspect that's where your QA failed, by only testing this in a subscription with resources that were created by the scripts in this repo. I'd suggest your QA practices evolve to properly encapsulate this type of testing in the future.
