### PR TITLE
chore: add CODEOWNERS baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+* @Azure-Samples/azure-logic-app-deployment-samples


### PR DESCRIPTION
## Summary

Adds a minimal team-based CODEOWNERS file for repository security baseline compliance.

## Audit evidence

- No CODEOWNERS file was found in standard locations: .github/CODEOWNERS, CODEOWNERS, docs/CODEOWNERS.
- No active branch ruleset requiring code-owner review was found during the read-only audit.
- Repository team Azure-Samples/azure-logic-app-deployment-samples already has admin access to this repo and is used as the CODEOWNERS team.

## Change

- Adds .github/CODEOWNERS with wildcard ownership by Azure-Samples/azure-logic-app-deployment-samples.

## Follow-up

A repo admin still needs to enable branch/ruleset protection that requires CODEOWNERS review before this fully satisfies the control.